### PR TITLE
return default ice servers when not using twilio

### DIFF
--- a/lib/ice.js
+++ b/lib/ice.js
@@ -7,6 +7,13 @@ if (process.env.TWILIO_SID && process.env.TWILIO_TOKEN) {
   var client = null
 }
 
+var DEFAULT_ICE_SERVERS = [
+  {
+    url: 'stun:23.21.150.121', // deprecated, replaced by `urls`
+    urls: 'stun:23.21.150.121'
+  }
+]
+
 var CACHE_LIFETIME = 5 * 60 * 1000 // 5 minutes
 var cachedPromise = null
 
@@ -15,7 +22,7 @@ function clearCache() {
 }
 
 exports.getICEServers = function () {
-  if (client == null) return Promise.resolve({})
+  if (client == null) return Promise.resolve(DEFAULT_ICE_SERVERS)
   if (cachedPromise) return cachedPromise
 
   cachedPromise = new Promise(function (resolve, reject) {


### PR DESCRIPTION
These are Google's STUN servers. The same defaults are used in
the simple-peer module.

fixes #24