### PR TITLE
pass 'mangle' option into uglify for smaller file size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublish": "npm run build:prod",
     "build:prod": "npm run build:prod:server && npm run build:prod:client",
     "build:prod:server": "./node_modules/.bin/babel lib -d dist",
-    "build:prod:client": "./node_modules/.bin/browserify lib/client.js -t babelify -t uglifyify | ./node_modules/.bin/uglifyjs -c > dist/client.js",
+    "build:prod:client": "./node_modules/.bin/browserify lib/client.js -t babelify -t uglifyify | ./node_modules/.bin/uglifyjs -cm > dist/client.js",
     "build:dev": "npm run build:dev:server && npm run build:dev:client",
     "build:dev:server": "./node_modules/.bin/babel lib -d dist -s inline",
     "build:dev:client": "./node_modules/.bin/browserify lib/client.js -t babelify -o dist/client.js -d",


### PR DESCRIPTION
Greetings! I think filepizza is really cool!

I tested the benefit of using `uglify -cm` (compress and mangle) over `uglify -c` (compress).

## uglify -c
```./node_modules/.bin/browserify lib/client.js -t babelify -t uglifyify | ./node_modules/.bin/uglifyjs -c | wc -c``` returns 1075064 bytes

## uglify -cm
```./node_modules/.bin/browserify lib/client.js -t babelify -t uglifyify | ./node_modules/.bin/uglifyjs -cm | wc -c``` returns 773875 bytes

It looks like thats a little bit more than a 30kb save!