### PR TITLE
Remove useless copyright statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
 Copyright (c) 2015, Alex Kern
-All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
"All rights reserved" should not be noted for FLOSS licenses. See https://github.com/kern/filepizza/issues/27