### PR TITLE
Send correct Content-Type headers for all resources

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -41,10 +41,10 @@ export default class App extends React.Component {
         <title>FilePizza - Your files, delivered.</title>
 
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Quicksand:300,400,700|Lobster+Two" />
-        <link rel="stylesheet" href="/css" />
+        <link rel="stylesheet" href="/app.css" />
 
         <Bootstrap data={this.props.data} />
-        <script src="/js" />
+        <script src="/app.js" />
 
       </FrozenHead>
 

--- a/src/middleware/javascript.js
+++ b/src/middleware/javascript.js
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV === 'production') {
   const webpackMiddleware = require('webpack-dev-middleware')
   const webpack = require('webpack')
   const config = require('../../webpack.config.js')
-  config.output.filename = '/js'
+  config.output.filename = '/app.js'
   config.output.path = '/'
   module.exports = webpackMiddleware(webpack(config))
 }

--- a/src/middleware/react.js
+++ b/src/middleware/react.js
@@ -20,6 +20,7 @@ module.exports = function (req, res) {
     var html = React.renderToString(<Handler data={alt.takeSnapshot()} />)
     alt.flush()
   
+    res.setHeader('Content-Type', 'text/html');
     if (isNotFound(state)) res.status(404)
     res.write('<!DOCTYPE html>\n')
     res.end(html)

--- a/src/server.js
+++ b/src/server.js
@@ -79,8 +79,8 @@ if (process.env.FORCE_SSL) {
   app.use(forceSSL)
 }
 
-app.get('/js', require('./middleware/javascript'))
-app.get('/css', require('./middleware/css'))
+app.get('/app.js', require('./middleware/javascript'))
+app.get('/app.css', require('./middleware/css'))
 app.use(require('./middleware/static'))
 
 app.use([


### PR DESCRIPTION
This pull request closes #46, by ensuring that all resources sent by FilePizza are being sent with a proper Content-Type to clients. Two changes were specifically done:

- Send **text/html** as **Content-Type** within the React middleware
- Renamed URLs for JS/CSS to **/app.js** and **/app.css**