### PR TITLE
Rename componentDidUnmount & move bind call to constructors

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -24,7 +24,7 @@ export default class App extends React.Component {
     SupportStore.listen(this._onChange)
   }
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     SupportStore.unlisten(this._onChange)
   }
 

--- a/src/components/ChromeNotice.js
+++ b/src/components/ChromeNotice.js
@@ -4,7 +4,7 @@ import SupportStore from '../stores/SupportStore'
 
 function getState() {
   return {
-    active: SupportStore.getState().isChrome && DownloadStore.getState().fileSize >= 500000000 
+    active: SupportStore.getState().isChrome && DownloadStore.getState().fileSize >= 500000000
   }
 }
 
@@ -24,7 +24,7 @@ export default class ChromeNotice extends React.Component {
     SupportStore.listen(this._onChange)
   }
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     DownloadStore.unlisten(this._onChange)
     SupportStore.unlisten(this._onChange)
   }

--- a/src/components/DownloadButton.js
+++ b/src/components/DownloadButton.js
@@ -1,6 +1,10 @@
 import React from 'react'
 
 export default class DownloadButton extends React.Component {
+  constructor() {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
 
   onClick(e) {
     this.props.onClick(e)
@@ -9,7 +13,7 @@ export default class DownloadButton extends React.Component {
   render() {
     return <button
       className="download-button"
-      onClick={this.onClick.bind(this)}>
+      onClick={this.onClick}>
       Download
     </button>
   }

--- a/src/components/DownloadPage.js
+++ b/src/components/DownloadPage.js
@@ -23,7 +23,7 @@ export default class DownloadPage extends React.Component {
     DownloadStore.listen(this._onChange)
   }
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     DownloadStore.unlisten(this._onChange)
   }
 

--- a/src/components/DownloadPage.js
+++ b/src/components/DownloadPage.js
@@ -17,6 +17,8 @@ export default class DownloadPage extends React.Component {
     this._onChange = () => {
       this.setState(DownloadStore.getState())
     }
+
+    this.downloadFile = this.downloadFile.bind(this)
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class DownloadPage extends React.Component {
 
           <ChromeNotice />
           <p className="notice">Peers: {this.state.peers} &middot; Up: {formatSize(this.state.speedUp)} &middot; Down: {formatSize(this.state.speedDown)}</p>
-          <DownloadButton onClick={this.downloadFile.bind(this)} />
+          <DownloadButton onClick={this.downloadFile} />
 
         </div>
 

--- a/src/components/DropZone.js
+++ b/src/components/DropZone.js
@@ -5,6 +5,11 @@ export default class DropZone extends React.Component {
   constructor() {
     super()
     this.state = { focus: false }
+
+    this.onDragEnter = this.onDragEnter.bind(this)
+    this.onDragLeave = this.onDragLeave.bind(this)
+    this.onDragOver = this.onDragOver.bind(this)
+    this.onDrop = this.onDrop.bind(this)
   }
 
   onDragEnter() {
@@ -31,10 +36,10 @@ export default class DropZone extends React.Component {
 
   render() {
     return <div className="drop-zone" ref="root"
-      onDragEnter={this.onDragEnter.bind(this)}
-      onDragLeave={this.onDragLeave.bind(this)}
-      onDragOver={this.onDragOver.bind(this)}
-      onDrop={this.onDrop.bind(this)}>
+      onDragEnter={this.onDragEnter}
+      onDragLeave={this.onDragLeave}
+      onDragOver={this.onDragOver}
+      onDrop={this.onDrop}>
 
       <div className="drop-zone-overlay"
         hidden={!this.state.focus}

--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -17,7 +17,7 @@ export default class ErrorPage extends React.Component {
     ErrorStore.listen(this._onChange)
   }
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     ErrorStore.unlisten(this._onChange)
   }
 

--- a/src/components/Tempalink.js
+++ b/src/components/Tempalink.js
@@ -1,6 +1,10 @@
 import React from 'react'
 
 export default class Tempalink extends React.Component {
+  constructor() {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
 
   onClick() {
     this.refs.input.getDOMNode().setSelectionRange(0, 9999)
@@ -10,7 +14,7 @@ export default class Tempalink extends React.Component {
     var url = window.location.origin + '/' + this.props.token
     return <input
       className="tempalink"
-      onClick={this.onClick.bind(this)}
+      onClick={this.onClick}
       readOnly
       ref="input"
       type="text"

--- a/src/components/UploadPage.js
+++ b/src/components/UploadPage.js
@@ -16,6 +16,8 @@ export default class UploadPage extends React.Component {
     this._onChange = () => {
       this.setState(UploadStore.getState())
     }
+
+    this.uploadFile = this.uploadFile.bind(this)
   }
 
   componentDidMount() {
@@ -25,7 +27,7 @@ export default class UploadPage extends React.Component {
   componentWillUnmount() {
     UploadStore.unlisten(this._onChange)
   }
-  
+
   uploadFile(file) {
     UploadActions.uploadFile(file)
   }
@@ -41,7 +43,7 @@ export default class UploadPage extends React.Component {
     switch (this.state.status) {
       case 'ready':
 
-        return <DropZone onDrop={this.uploadFile.bind(this)}>
+        return <DropZone onDrop={this.uploadFile}>
           <div className="page">
 
             <Spinner dir="up" />

--- a/src/components/UploadPage.js
+++ b/src/components/UploadPage.js
@@ -12,40 +12,40 @@ export default class UploadPage extends React.Component {
   constructor() {
     super()
     this.state = UploadStore.getState()
-  
+
     this._onChange = () => {
       this.setState(UploadStore.getState())
     }
   }
-  
+
   componentDidMount() {
     UploadStore.listen(this._onChange)
   }
-  
-  componentDidUnmount() {
+
+  componentWillUnmount() {
     UploadStore.unlisten(this._onChange)
   }
   
   uploadFile(file) {
     UploadActions.uploadFile(file)
   }
-  
+
   handleSelectedFile(event) {
     let files = event.target.files
     if (files.length > 0) {
       UploadActions.uploadFile(files[0])
     }
   }
-  
+
   render() {
     switch (this.state.status) {
       case 'ready':
-  
+
         return <DropZone onDrop={this.uploadFile.bind(this)}>
           <div className="page">
-  
+
             <Spinner dir="up" />
-  
+
             <h1>FilePizza</h1>
             <p>Free peer-to-peer file transfers in your browser.</p>
             <p>We never store anything. Files only served fresh.</p>
@@ -57,30 +57,30 @@ export default class UploadPage extends React.Component {
             </p>
           </div>
         </DropZone>
-  
+
       case 'processing':
         return <div className="page">
-  
+
           <Spinner dir="up" animated />
-  
+
           <h1>FilePizza</h1>
           <p>Processing...</p>
-  
+
         </div>
-  
+
       case 'uploading':
         return <div className="page">
-  
+
           <h1>FilePizza</h1>
           <Spinner dir="up" animated
             name={this.state.fileName}
             size={this.state.fileSize} />
-  
+
           <p>Send someone this link to download.</p>
           <p>This link will work as long as this page is open.</p>
           <p>Peers: {this.state.peers} &middot; Up: {formatSize(this.state.speedUp)}</p>
           <Tempalink token={this.state.token} />
-  
+
         </div>
     }
   }

--- a/src/components/Uploader.js
+++ b/src/components/Uploader.js
@@ -3,6 +3,10 @@ import React from 'react';
 import UploadActions from '@app/actions/UploadActions';
 
 export default class UploadPage extends React.Component {
+  constructor() {
+    super()
+    this.uploadFile = this.uploadFile.bind(this)
+  }
 
   uploadFile(file) {
     UploadActions.uploadFile(file);
@@ -12,7 +16,7 @@ export default class UploadPage extends React.Component {
     switch (this.props.status) {
       case 'ready':
         return <div>
-          <DropZone onDrop={this.uploadFile.bind(this)} />
+          <DropZone onDrop={this.uploadFile} />
           <Arrow dir="up" />
         </div>;
         break;


### PR DESCRIPTION
This PR fixes issue https://github.com/kern/filepizza/issues/34 and moves call to bind into the class constructor. 
The two PR's have comments and links to docs. 
- https://github.com/tomsapps/filepizza/pull/1 (ComponentDidUnmount fix)
- https://github.com/tomsapps/filepizza/pull/2 (Move call to bind)

Please let me know if this contribution flow is ok. Not sure if you all prefer to merge feature branches from forks.