### PR TITLE
Add environment variable to disable Google Analytics.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:latest
 MAINTAINER Alex Kern <alex@kern.io>
 
-ENV DISABLE_GA no
+ENV DISABLE_GA yes
  
 COPY . ./
 RUN npm install && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:latest
 MAINTAINER Alex Kern <alex@kern.io>
+
+ENV DISABLE_GA no
  
 COPY . ./
 RUN npm install && npm run build

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Using [WebRTC](http://www.webrtc.org), FilePizza eliminates the initial upload s
 
 A hosted instance of FilePizza is available at [file.pizza](https://file.pizza).
 
+The Dockerfile in this branch is modified to disable Google Analytics by default, which should be preferable for self-hosted instances.
+
 ## Requirements
 
 * node `0.12.x`
@@ -13,9 +15,9 @@ A hosted instance of FilePizza is available at [file.pizza](https://file.pizza).
 
 ## Installation
 
-The recommended way to deploy FilePizza is as a [Docker container](https://hub.docker.com/r/kern/filepizza).
+The recommended way to deploy FilePizza is as a [Docker container](https://hub.docker.com/r/andreipoe/filepizza-no-ga).
 
-    $ docker run -p 8080:8080 -e PORT=8080 -it kern/filepizza:latest
+    $ docker run -d --name filepizza --restart unless-stopped -p 8080:8080 -e PORT=8080 andreipoe/filepizza-no-ga
 
 You can also use [zeit/now](https://zeit.co/now):
 
@@ -25,7 +27,7 @@ If you'd like to use [Twilio's STUN/TURN service](https://www.twilio.com/stun-tu
 
 ## Development
 
-    $ git clone https://github.com/kern/filepizza.git
+    $ git clone https://github.com/andreipoe/filepizza.git -b disable-ga
     $ npm install
     $ npm build
     $ npm start

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -5,9 +5,14 @@ import React from "react";
 import SupportStore from "../stores/SupportStore";
 import { RouteHandler } from "react-router";
 import ga from "react-google-analytics";
-
-ga("create", "UA-62785624-1", "auto");
-ga("send", "pageview");
+ 
+if (process.env.DISABLE_GA != 'yes') {
+  ga("create", "UA-62785624-1", "auto");
+  ga("send", "pageview");
+  console.log("Google Analytics ON");
+}
+else
+  console.log("Google Analytics OFF");
 
 export default class App extends React.Component {
   constructor() {
@@ -89,7 +94,7 @@ export default class App extends React.Component {
             </p>
           </footer>
           <script>FilePizza()</script>
-          <ga.Initializer />
+          { process.env.DISABLE_GA != 'yes' && <ga.Initializer /> }
         </body>
       </html>
     );

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -94,7 +94,7 @@ export default class App extends React.Component {
             </p>
           </footer>
           <script>FilePizza()</script>
-          { process.env.DISABLE_GA != 'yes' && <ga.Initializer /> }
+          { process.env.DISABLE_GA != 'yes' ? <ga.Initializer /> : <div></div> }
         </body>
       </html>
     );

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "webpack-dev-middleware": "^1.6.1",
     "webrtcsupport": "^2.2.0",
     "winston": "^1.0.1",
-    "xkcd-password": "^1.2.0"
+    "xkcd-password": "^1.2.0",
+    "noop-loader": "*",
+    "null-loader": "*",
+    "stylus": "^0.50.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const nib = require("nib");
+const webpack = require('webpack')
 
 module.exports = {
   entry: "./lib/client",
@@ -26,11 +27,24 @@ module.exports = {
     ]
   },
 
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'DISABLE_GA': process.env.DISABLE_GA,
+      }
+    })
+  ],
+
   node: {
     fs: "empty"
   },
 
   stylus: {
     use: [nib()]
-  }
+  },
+
+  rules: [{
+    test: /react-google-analytics/,
+    use: process.env.DISABLE_GA ? 'null-loader' : 'noop-loader'
+  }]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        'DISABLE_GA': process.env.DISABLE_GA,
+        'DISABLE_GA': JSON.stringify(process.env.DISABLE_GA),
       }
     })
   ],


### PR DESCRIPTION
Hi @kern,

Would something like this do for #57? Setting `DISABLE_GA=yes` (either in your build shell or in the Docker build) should remove the GA parts, as required.

Thanks!