### PR TITLE
Update Dockerfile to alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:alpine
 MAINTAINER Alex Kern <alex@kern.io>
  
 COPY . ./


### PR DESCRIPTION
This will use the latest node alpine image instead of the latest default. This brings the container size down from ~777MB to ~173MB; about 88% smaller.