### PR TITLE
Fix NPM Stylus dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "socket.io": "^1.3.5",
     "socket.io-client": "^1.3.5",
     "style-loader": "^0.18.2",
-    "stylus": "^0.50.0",
+    "stylus": "^0.52.4",
     "stylus-loader": "^3.0.1",
     "twilio": "^2.9.1",
     "webpack": "^1.12.14",


### PR DESCRIPTION
NPM3 installs stylus 0.50.0, and then tries to
install stylus-loader 3.0.1, but it actually
requires stylus >= 0.52.4.