### PR TITLE
Add CSS font border for spinner texts

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -175,6 +175,10 @@ small {
         text-overflow: ellipsis
         white-space: nowrap
         margin-top: 10px
+        text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+        font-weight: bolder;
+        font-family: "Arial";
+        overflow: visible;
     }
 
     .spinner-size {

--- a/src/index.styl
+++ b/src/index.styl
@@ -187,7 +187,6 @@ small {
         color: white
         text-overflow: ellipsis
         white-space: nowrap
-
         text-shadow: -1px 0 #000,0 1px #000,1px 0 #000,0 -1px #000;
     }
 }

--- a/src/index.styl
+++ b/src/index.styl
@@ -187,6 +187,7 @@ small {
         color: white
         text-overflow: ellipsis
         white-space: nowrap
+
         text-shadow: -1px 0 #000,0 1px #000,1px 0 #000,0 -1px #000;
     }
 }

--- a/src/index.styl
+++ b/src/index.styl
@@ -185,9 +185,9 @@ small {
         font: italic 12px/20px "Quicksand", sans-serif
         text-align: center
         color: white
-        overflow: hidden
         text-overflow: ellipsis
         white-space: nowrap
+        text-shadow: -1px 0 #000,0 1px #000,1px 0 #000,0 -1px #000;
     }
 }
 


### PR DESCRIPTION
This is a very small CSS change to address the following issue:

**Before:**
<img width="636" alt="screen-before" src="https://user-images.githubusercontent.com/5388534/71817422-18ea9880-3086-11ea-9fee-7c98b514a0b1.png">

**After:**
<img width="624" alt="screen-after" src="https://user-images.githubusercontent.com/5388534/71817434-20aa3d00-3086-11ea-8ea6-ea67fd09ac96.png">
