### PR TITLE
Fix QR Code Scanning Issue in Dark Mode by Adding White Border (#231)

### DIFF
--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -53,7 +53,7 @@ export default function Uploader({
   return (
     <>
       <div className="flex w-full items-center">
-        <div className="flex-none mr-4">
+        <div className="flex-none mr-4 bg-white p-2">
           <QRCode value={shortURL ?? ''} size={QR_CODE_SIZE} />
         </div>
         <div className="flex-auto flex flex-col justify-center space-y-2">


### PR DESCRIPTION
This merge request fixes issue #231, where QR codes were not scannable in dark mode due to the lack of a white border. The fix ensures that a proper white margin is added around the QR code, improving its readability across different themes.
	•	Added a white border to QR codes to ensure proper contrast.
	•	Verified that the QR codes remain scannable in both light and dark modes.
	•	Tested the fix across multiple devices and QR code scanners.

This update enhances usability and ensures a better user experience in dark mode.