### PR TITLE
fix: enhance clipboard functionality with fallback

### DIFF
--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -10,10 +10,40 @@ export default function useClipboard(
   const [hasCopied, setHasCopied] = useState(false)
 
   const onCopy = useCallback(() => {
-    navigator.clipboard.writeText(text).then(() => {
-      setHasCopied(true)
-    })
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          setHasCopied(true)
+        })
+        .catch((error) => {
+          console.error('Clipboard API error:', error)
+          fallbackCopyText(text)
+        })
+    } else {
+      fallbackCopyText(text)
+    }
   }, [text])
+
+  const fallbackCopyText = (textToCopy: string) => {
+    const textArea = document.createElement('textarea')
+    textArea.value = textToCopy
+
+    textArea.style.position = 'absolute'
+    textArea.style.left = '-999999px'
+
+    document.body.appendChild(textArea)
+    textArea.select()
+
+    try {
+      document.execCommand('copy')
+      setHasCopied(true)
+    } catch (error) {
+      console.error('execCommand:', error)
+    } finally {
+      textArea.remove()
+    }
+  }
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout


### PR DESCRIPTION
The copy button will throw an error if used outside localhost without HTTPS environment ([secure context](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText#security_considerations)) like in the image below.


![error](https://github.com/user-attachments/assets/c498d3b8-bb54-4c90-ae13-4f783807d0c0)


It can solve using the out of viewport hidden text area trick with`document.execCommand('copy');`