### PR TITLE
Added support for "sharedSlug" where multiple uploaders can share files

### DIFF
--- a/src/app/api/create/route.ts
+++ b/src/app/api/create/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { getOrCreateChannelRepo } from '../../../channel'
 
 export async function POST(request: Request): Promise<NextResponse> {
-  const { uploaderPeerID } = await request.json()
+  const { uploaderPeerID, sharedSlug } = await request.json()
 
   if (!uploaderPeerID) {
     return NextResponse.json(
@@ -11,6 +11,6 @@ export async function POST(request: Request): Promise<NextResponse> {
     )
   }
 
-  const channel = await getOrCreateChannelRepo().createChannel(uploaderPeerID)
+  const channel = await getOrCreateChannelRepo().createChannel(uploaderPeerID, undefined, sharedSlug)
   return NextResponse.json(channel)
 }

--- a/src/app/download/[...slug]/page.tsx
+++ b/src/app/download/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { getOrCreateChannelRepo } from '../../../channel'
 import Spinner from '../../../components/Spinner'
 import Wordmark from '../../../components/Wordmark'
 import Downloader from '../../../components/Downloader'
+import MultiDownloader from '../../../components/MultiDownloader'
 import WebRTCPeerProvider from '../../../components/WebRTCProvider'
 import ReportTermsViolationButton from '../../../components/ReportTermsViolationButton'
 
@@ -33,7 +34,14 @@ export default async function DownloadPage({
       <Spinner direction="down" />
       <Wordmark />
       <WebRTCPeerProvider>
-        <Downloader uploaderPeerID={channel.uploaderPeerID} />
+        {channel.additionalUploaders && channel.additionalUploaders.length > 0 ? (
+          <MultiDownloader
+            primaryUploaderID={channel.uploaderPeerID}
+            additionalUploaders={channel.additionalUploaders}
+          />
+        ) : (
+          <Downloader uploaderPeerID={channel.uploaderPeerID} />
+        )}
         <ReportTermsViolationButton
           uploaderPeerID={channel.uploaderPeerID}
           slug={slug}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,20 @@
 'use client'
 
-import React, { JSX, useCallback, useState } from 'react'
+import React, { JSX, useCallback, useState, useMemo } from 'react'
+import { getFileName } from '../fs'
+import { UploadedFile } from '../types'
+import { pluralize } from '../utils/pluralize'
 import WebRTCPeerProvider from '../components/WebRTCProvider'
 import DropZone from '../components/DropZone'
 import UploadFileList from '../components/UploadFileList'
 import Uploader from '../components/Uploader'
 import PasswordField from '../components/PasswordField'
+import SharedLinkField from '../components/SharedLinkField'
 import StartButton from '../components/StartButton'
-import { UploadedFile } from '../types'
 import Spinner from '../components/Spinner'
 import Wordmark from '../components/Wordmark'
 import CancelButton from '../components/CancelButton'
-import { useMemo } from 'react'
-import { getFileName } from '../fs'
 import TitleText from '../components/TitleText'
-import { pluralize } from '../utils/pluralize'
 import TermsAcceptance from '../components/TermsAcceptance'
 
 function PageWrapper({ children }: { children: React.ReactNode }): JSX.Element {
@@ -52,17 +52,33 @@ function useUploaderFileListData(uploadedFiles: UploadedFile[]) {
   }, [uploadedFiles])
 }
 
+function extractSlugFromLink(link: string): string | undefined {
+  if (!link) return undefined
+
+  try {
+    const url = new URL(link)
+    const pathParts = url.pathname.split('/')
+    return pathParts[pathParts.length - 1]
+  } catch {
+    return link.trim() ? link.trim() : undefined
+  }
+}
+
 function ConfirmUploadState({
   uploadedFiles,
   password,
+  sharedLink,
   onChangePassword,
+  onChangeSharedLink,
   onCancel,
   onStart,
   onRemoveFile,
 }: {
   uploadedFiles: UploadedFile[]
   password: string
+  sharedLink: string
   onChangePassword: (pw: string) => void
+  onChangeSharedLink: (link: string) => void
   onCancel: () => void
   onStart: () => void
   onRemoveFile: (index: number) => void
@@ -76,6 +92,7 @@ function ConfirmUploadState({
       </TitleText>
       <UploadFileList files={fileListData} onRemove={onRemoveFile} />
       <PasswordField value={password} onChange={onChangePassword} />
+      <SharedLinkField value={sharedLink} onChange={onChangeSharedLink} />
       <div className="flex space-x-4">
         <CancelButton onClick={onCancel} />
         <StartButton onClick={onStart} />
@@ -87,13 +104,17 @@ function ConfirmUploadState({
 function UploadingState({
   uploadedFiles,
   password,
+  sharedLink,
   onStop,
 }: {
   uploadedFiles: UploadedFile[]
   password: string
+  sharedLink: string
   onStop: () => void
 }): JSX.Element {
   const fileListData = useUploaderFileListData(uploadedFiles)
+  const sharedSlug = extractSlugFromLink(sharedLink)
+
   return (
     <PageWrapper>
       <TitleText>
@@ -101,7 +122,7 @@ function UploadingState({
       </TitleText>
       <UploadFileList files={fileListData} />
       <WebRTCPeerProvider>
-        <Uploader files={uploadedFiles} password={password} onStop={onStop} />
+        <Uploader files={uploadedFiles} password={password} sharedSlug={sharedSlug} onStop={onStop} />
       </WebRTCPeerProvider>
     </PageWrapper>
   )
@@ -110,6 +131,7 @@ function UploadingState({
 export default function UploadPage(): JSX.Element {
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([])
   const [password, setPassword] = useState('')
+  const [sharedLink, setSharedLink] = useState('')
   const [uploading, setUploading] = useState(false)
 
   const handleDrop = useCallback((files: UploadedFile[]): void => {
@@ -118,6 +140,10 @@ export default function UploadPage(): JSX.Element {
 
   const handleChangePassword = useCallback((pw: string) => {
     setPassword(pw)
+  }, [])
+
+  const handleChangeSharedLink = useCallback((link: string) => {
+    setSharedLink(link)
   }, [])
 
   const handleStart = useCallback(() => {
@@ -146,7 +172,9 @@ export default function UploadPage(): JSX.Element {
       <ConfirmUploadState
         uploadedFiles={uploadedFiles}
         password={password}
+        sharedLink={sharedLink}
         onChangePassword={handleChangePassword}
+        onChangeSharedLink={handleChangeSharedLink}
         onCancel={handleCancel}
         onStart={handleStart}
         onRemoveFile={handleRemoveFile}
@@ -158,6 +186,7 @@ export default function UploadPage(): JSX.Element {
     <UploadingState
       uploadedFiles={uploadedFiles}
       password={password}
+      sharedLink={sharedLink}
       onStop={handleStop}
     />
   )

--- a/src/components/MultiDownloader.tsx
+++ b/src/components/MultiDownloader.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import React, { useState, JSX, useEffect } from 'react'
+import Downloader from './Downloader'
+
+export default function MultiDownloader({
+  primaryUploaderID,
+  additionalUploaders,
+}: {
+  primaryUploaderID: string
+  additionalUploaders: string[]
+}): JSX.Element {
+  const [selectedUploader, setSelectedUploader] = useState<string>(primaryUploaderID)
+  const [key, setKey] = useState<number>(0)
+  const allUploaders = [primaryUploaderID, ...additionalUploaders]
+
+  useEffect(() => {
+    setKey(prevKey => prevKey + 1)
+  }, [selectedUploader])
+
+  return (
+    <div className="w-full flex flex-col items-center">
+      <div className="w-full mb-4">
+        <h3 className="text-center mb-2 text-stone-700 dark:text-stone-300">
+          Multiple uploaders available for this shared link:
+        </h3>
+        <div className="flex flex-wrap justify-center gap-2 mb-4">
+          {allUploaders.map((uploader, i) => (
+            <button
+              key={uploader}
+              onClick={() => setSelectedUploader(uploader)}
+              className={`px-3 py-1 rounded transition-colors duration-200 ${
+                selectedUploader === uploader 
+                  ? 'bg-green-500 text-white' 
+                  : 'bg-stone-200 dark:bg-stone-700 text-stone-800 dark:text-stone-200 hover:bg-stone-300 dark:hover:bg-stone-600'
+              }`}
+            >
+              Uploader {i + 1}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Downloader key={key} uploaderPeerID={selectedUploader} />
+    </div>
+  )
+}

--- a/src/components/SharedLinkField.tsx
+++ b/src/components/SharedLinkField.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import React, { JSX, useCallback } from 'react'
+import InputLabel from './InputLabel'
+
+export default function SharedLinkField({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (v: string) => void
+}): JSX.Element {
+  const handleChange = useCallback(
+    function (e: React.ChangeEvent<HTMLInputElement>): void {
+      onChange(e.target.value)
+    },
+    [onChange],
+  )
+
+  return (
+    <div className="flex flex-col w-full">
+      <InputLabel
+        tooltip="Enter a shared link to collaborate with other uploaders. If this is filled, others with the same link will be able to provide the same files to downloaders. Leave empty to create a new upload."
+      >
+        Shared Link (optional)
+      </InputLabel>
+      <input
+        type="text"
+        className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100"
+        placeholder="Paste a shared link to collaborate with others..."
+        value={value}
+        onChange={handleChange}
+      />
+      <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+        You can paste either a full URL or just the slug. When shared, multiple uploaders can provide the same files, making downloads more reliable.
+      </p>
+    </div>
+  )
+}

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -18,15 +18,17 @@ const QR_CODE_SIZE = 128
 export default function Uploader({
   files,
   password,
+  sharedSlug,
   onStop,
 }: {
   files: UploadedFile[]
   password: string
+  sharedSlug?: string
   onStop: () => void
 }): JSX.Element {
   const { peer, stop } = useWebRTCPeer()
-  const { isLoading, error, longSlug, shortSlug, longURL, shortURL } =
-    useUploaderChannel(peer.id)
+  const { isLoading, error, longSlug, shortSlug, longURL, shortURL, sharedURL } =
+    useUploaderChannel(peer.id, 60000, sharedSlug)
   const connections = useUploaderConnections(peer, files, password)
 
   const handleStop = useCallback(() => {
@@ -59,6 +61,16 @@ export default function Uploader({
         <div className="flex-auto flex flex-col justify-center space-y-2">
           <CopyableInput label="Long URL" value={longURL ?? ''} />
           <CopyableInput label="Short URL" value={shortURL ?? ''} />
+          {sharedURL && (
+            <>
+              <CopyableInput label="Shared URL" value={sharedURL} />
+              {sharedSlug && (
+                <div className="text-xs text-green-600 dark:text-green-400">
+                  This upload is part of a collaborative shared link. Multiple uploaders can serve the same files.
+                </div>
+              )}
+            </>
+          )}
         </div>
       </div>
       <div className="mt-6 pt-4 border-t border-stone-200 dark:border-stone-700 w-full">


### PR DESCRIPTION
Added an option to upload to a shared slug. If the shared slug is specified on upload, the short and long slugs are still generated specifically for that connection. Additionally, the shared slug will provide a connection for each uploader independently. This approach respects the current filepizza specifications, including multiple file uploads, and password setting for individual uploader files.

Currently, I do not implement means for deleting stale uploader connections since there are multiple ways to deal with it, and I would rather leave it to the filepizza authors to decide how to approach this.

**Future Suggestion**:
* ATM, each uploader is enumerated during download. Uploaders could potentially also specify a username during upload
* If one downloader cannot connect to an uploader, they could be deleted from the `additionalUploaders` list. This is problematic however, since one downloader being unable to establish a connection with an uploader does not mean the upload is not available for others
* Add a `keep-alive` signal that maintains connections to available uploaders. The upload connection is discarded after multiple failed attempts to connect
* Alternatively, uploaders could be discarded independently after a static TTL is exceeded