### PR TITLE
Add upload/download e2e test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,3 +20,9 @@ jobs:
       - run: pnpm test
       - run: pnpm build
       - run: pnpm test:e2e
+      - name: Upload Playwright results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: test-results

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
   testDir: './tests/e2e',
   webServer: {
-    command: 'node .next/standalone/server.js',
-    port: 3000,
+    command: 'PORT=4100 node .next/standalone/server.js',
+    port: 4100,
     timeout: 120 * 1000,
     reuseExistingServer: true,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,9 +3,13 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
   testDir: './tests/e2e',
   webServer: {
-    command: 'PORT=4100 node .next/standalone/server.js',
+    command: 'HOSTNAME=127.0.0.1 PORT=4100 node .next/standalone/server.js',
     port: 4100,
     timeout: 120 * 1000,
     reuseExistingServer: true,
+  },
+  use: {
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
   },
 })

--- a/tests/e2e/basic.test.ts
+++ b/tests/e2e/basic.test.ts
@@ -2,7 +2,7 @@
 import { test, expect } from '@playwright/test'
 
 test('home page loads', async ({ page }) => {
-  await page.goto('http://localhost:3000/')
+  await page.goto('http://localhost:4100/')
   await expect(
     page.getByText('Peer-to-peer file transfers in your browser.'),
   ).toBeVisible()

--- a/tests/e2e/fixtures/testfile.txt
+++ b/tests/e2e/fixtures/testfile.txt
@@ -1,0 +1,1 @@
+hello from filepizza

--- a/tests/e2e/upload-download.test.ts
+++ b/tests/e2e/upload-download.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+
+const testFilePath = path.join(__dirname, 'fixtures', 'testfile.txt')
+
+function sha256(file: Buffer): string {
+  return crypto.createHash('sha256').update(file).digest('hex')
+}
+
+test('uploader to downloader transfer', async ({ browser }) => {
+  const fileBuffer = fs.readFileSync(testFilePath)
+  const expectedChecksum = sha256(fileBuffer)
+
+  const uploader = await browser.newPage()
+  await uploader.goto('http://localhost:4100/')
+  await uploader.setInputFiles('input[type="file"]', testFilePath)
+  await uploader.getByText('Start').click()
+
+  const shortInput = uploader.getByText('Short URL').locator('..').locator('input')
+  await expect(shortInput).toBeVisible()
+  const shareURL = await shortInput.inputValue()
+
+  const downloader = await browser.newPage()
+  await downloader.goto(shareURL)
+  const downloadPromise = downloader.waitForEvent('download')
+  await downloader.getByText('Download').click()
+  const download = await downloadPromise
+  const downloadedPath = await download.path()
+  const downloadedBuffer = fs.readFileSync(downloadedPath!)
+  expect(sha256(downloadedBuffer)).toBe(expectedChecksum)
+})

--- a/tests/e2e/upload-download.test.ts
+++ b/tests/e2e/upload-download.test.ts
@@ -19,7 +19,7 @@ test('uploader to downloader transfer', async ({ browser }) => {
   await uploader.getByText('Start').click()
 
   const shortInput = uploader.getByText('Short URL').locator('..').locator('input')
-  await expect(shortInput).toBeVisible()
+  await expect(shortInput).toBeVisible({ timeout: 15000 })
   const shareURL = await shortInput.inputValue()
 
   const downloader = await browser.newPage()


### PR DESCRIPTION
## Summary
- update playwright config to run on port 4100
- adjust existing basic e2e test for new port
- add an end-to-end test for uploading a file and downloading it in another browser
- include a small text fixture used for the test

## Testing
- `pnpm test:e2e` *(fails: browser executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68634fa8800c83248a74fb9ba0902940