### PR TITLE
Fix final chunk detection

### DIFF
--- a/src/hooks/useUploaderConnections.ts
+++ b/src/hooks/useUploaderConnections.ts
@@ -10,7 +10,11 @@ import { getFileName } from '../fs'
 import { setRotating } from './useRotatingSpinner'
 
 // TODO(@kern): Test for better values
-const MAX_CHUNK_SIZE = 256 * 1024 // 256 KB
+export const MAX_CHUNK_SIZE = 256 * 1024 // 256 KB
+
+export function isFinalChunk(offset: number, fileSize: number): boolean {
+  return offset + MAX_CHUNK_SIZE >= fileSize
+}
 
 function validateOffset(
   files: UploadedFile[],
@@ -227,8 +231,7 @@ export function useUploaderConnections(
               const sendNextChunkAsync = () => {
                 sendChunkTimeout = setTimeout(() => {
                   const end = Math.min(file.size, offset + MAX_CHUNK_SIZE)
-                  const chunkSize = end - offset
-                  const final = chunkSize < MAX_CHUNK_SIZE
+                  const final = isFinalChunk(offset, file.size)
                   const request: Message = {
                     type: MessageType.Chunk,
                     fileName,

--- a/tests/unit/isFinalChunk.test.ts
+++ b/tests/unit/isFinalChunk.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { isFinalChunk, MAX_CHUNK_SIZE } from '../../src/hooks/useUploaderConnections'
+
+describe('isFinalChunk', () => {
+  it('marks last chunk when file size is exact multiple of chunk size', () => {
+    const fileSize = MAX_CHUNK_SIZE * 2
+    // when offset points to start of last chunk
+    expect(isFinalChunk(MAX_CHUNK_SIZE, fileSize)).toBe(true)
+  })
+
+  it('returns false for middle chunks', () => {
+    const fileSize = MAX_CHUNK_SIZE * 3 + 123
+    expect(isFinalChunk(MAX_CHUNK_SIZE, fileSize)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- correctly detect the last chunk when sending files
- expose helper for determining last chunk
- test isFinalChunk logic

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875f280aa2c8324bdd9f69ed3fcb2c3