### PR TITLE
Make STUN server configurable

### DIFF
--- a/src/app/api/ice/route.ts
+++ b/src/app/api/ice/route.ts
@@ -3,11 +3,12 @@ import crypto from 'crypto'
 import { setTurnCredentials } from '../../../coturn'
 
 const turnHost = process.env.TURN_HOST || '127.0.0.1'
+const stunServer = process.env.STUN_SERVER || 'stun:stun.l.google.com:19302'
 
 export async function POST(): Promise<NextResponse> {
   if (!process.env.COTURN_ENABLED) {
     return NextResponse.json({
-      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+      iceServers: [{ urls: stunServer }],
     })
   }
 
@@ -21,7 +22,7 @@ export async function POST(): Promise<NextResponse> {
 
   return NextResponse.json({
     iceServers: [
-      { urls: 'stun:stun.l.google.com:19302' },
+      { urls: stunServer },
       {
         urls: [`turn:${turnHost}:3478`, `turns:${turnHost}:5349`],
         username,


### PR DESCRIPTION
## Summary
- allow overriding the default STUN server with `STUN_SERVER`

## Testing
- `pnpm test`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm type:check`


------
https://chatgpt.com/codex/tasks/task_e_68786d767eb08324ad49be9937944904