### PR TITLE
Make STUN server configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ $ pnpm docker:down
 * View Transitions
 * Redis (optional)
 
+## Configuration
+
+The server can be customized with the following environment variables:
+
+- `REDIS_URL` – Connection string for a Redis instance used to store channel metadata. If not set, FilePizza falls back to in-memory storage.
+- `COTURN_ENABLED` – When set to `true`, enables TURN support for connecting peers behind NAT.
+- `TURN_HOST` – Hostname or IP address of the TURN server. Defaults to `127.0.0.1`.
+- `TURN_REALM` – Realm used when generating TURN credentials. Defaults to `file.pizza`.
+- `STUN_SERVER` – STUN server URL to use when `COTURN_ENABLED` is disabled. Defaults to `stun:stun.l.google.com:19302`.
+
 ## FAQ
 
 **How are my files sent?** Your files are sent directly from your browser to the downloader's browser. They never pass through our servers. FilePizza uses WebRTC to send files. This requires that the uploader leave their browser window open until the transfer is complete.

--- a/src/app/api/ice/route.ts
+++ b/src/app/api/ice/route.ts
@@ -3,11 +3,12 @@ import crypto from 'crypto'
 import { setTurnCredentials } from '../../../coturn'
 
 const turnHost = process.env.TURN_HOST || '127.0.0.1'
+const stunServer = process.env.STUN_SERVER || 'stun:stun.l.google.com:19302'
 
 export async function POST(): Promise<NextResponse> {
   if (!process.env.COTURN_ENABLED) {
     return NextResponse.json({
-      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+      iceServers: [{ urls: stunServer }],
     })
   }
 
@@ -21,7 +22,7 @@ export async function POST(): Promise<NextResponse> {
 
   return NextResponse.json({
     iceServers: [
-      { urls: 'stun:stun.l.google.com:19302' },
+      { urls: stunServer },
       {
         urls: [`turn:${turnHost}:3478`, `turns:${turnHost}:5349`],
         username,


### PR DESCRIPTION
## Summary
- allow overriding the default STUN server with `STUN_SERVER`
- document environment variable configuration options

## Testing
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm type:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68786d767eb08324ad49be9937944904