### PR TITLE
Add upload page subtitle

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import CancelButton from '../components/CancelButton'
 import { useMemo } from 'react'
 import { getFileName } from '../fs'
 import TitleText from '../components/TitleText'
+import SubtitleText from '../components/SubtitleText'
 import { pluralize } from '../utils/pluralize'
 import TermsAcceptance from '../components/TermsAcceptance'
 
@@ -36,6 +37,10 @@ function InitialState({
     <PageWrapper>
       <div className="flex flex-col items-center space-y-1 max-w-md">
         <TitleText>Peer-to-peer file transfers in your browser.</TitleText>
+        <SubtitleText>
+          Leave this tab open—FilePizza is peer to peer and never stores your
+          files.
+        </SubtitleText>
       </div>
       <DropZone onDrop={onDrop} />
       <TermsAcceptance />

--- a/src/components/SubtitleText.tsx
+++ b/src/components/SubtitleText.tsx
@@ -1,0 +1,13 @@
+import React, { JSX } from 'react'
+
+export default function SubtitleText({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element {
+  return (
+    <p className="text-sm text-center text-stone-600 dark:text-stone-400 max-w-md">
+      {children}
+    </p>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `SubtitleText` component for small page notes
- include an uploader note to keep tab open while sharing

## Testing
- `pnpm lint:check`
- `pnpm type:check`
- `pnpm test`
- `pnpm test:e2e` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68786d2ea6f483249e8860d6b05a78e0