### PR TITLE
Inline add-files link in confirmation screen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,12 +76,10 @@ function ConfirmUploadState({
     <PageWrapper>
       <TitleText>
         You are about to start uploading{' '}
-        {pluralize(uploadedFiles.length, 'file', 'files')}.
+        {pluralize(uploadedFiles.length, 'file', 'files')}.{' '}
+        <AddFilesButton onAdd={onAddFiles} />
       </TitleText>
       <UploadFileList files={fileListData} onRemove={onRemoveFile} />
-      <div className="flex justify-end w-full">
-        <AddFilesButton onAdd={onAddFiles} />
-      </div>
       <PasswordField value={password} onChange={onChangePassword} />
       <div className="flex space-x-4">
         <CancelButton onClick={onCancel} />

--- a/src/components/AddFilesButton.tsx
+++ b/src/components/AddFilesButton.tsx
@@ -36,7 +36,7 @@ export default function AddFilesButton({
         id="add-files-button"
         type="button"
         onClick={handleClick}
-        className="block cursor-pointer relative py-3 px-6 text-base font-bold text-stone-700 dark:text-stone-200 bg-white dark:bg-stone-800 border-2 border-stone-700 dark:border-stone-700 rounded-lg transition-all duration-300 ease-in-out outline-none hover:shadow-md active:shadow-inner focus:shadow-outline"
+        className="text-sm underline text-stone-700 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-100 transition-colors duration-200"
       >
         Add more files
       </button>


### PR DESCRIPTION
## Summary
- Replace standalone Add Files button with a small link inline with upload confirmation title
- Style Add Files control as simple text link

## Testing
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm type:check`
- `pnpm test`
- `pnpm test:e2e` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68903f48cba88324833f9c818e2aa3f2