### PR TITLE
Add local host and path for peerjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The server can be customized with the following environment variables:
 - `TURN_HOST` – Hostname or IP address of the TURN server. Defaults to `127.0.0.1`.
 - `TURN_REALM` – Realm used when generating TURN credentials. Defaults to `file.pizza`.
 - `STUN_SERVER` – STUN server URL to use when `COTURN_ENABLED` is disabled. Defaults to `stun:stun.l.google.com:19302`.
+- `PEERJS_HOST` – Hostname or IP address to the self-hosted PeerJS server. Defaults to `0.peerjs.com`.
+- `PEERJS_PATH` – Path to self-hosted PeerJS server. Defaults to `/`.
 
 ## FAQ
 

--- a/src/app/api/ice/route.ts
+++ b/src/app/api/ice/route.ts
@@ -4,10 +4,7 @@ import { setTurnCredentials } from '../../../coturn'
 
 const turnHost = process.env.TURN_HOST || '127.0.0.1'
 const stunServer = process.env.STUN_SERVER || 'stun:stun.l.google.com:19302'
-
-// PATCH(gingermuffin):
-// Create host and path to local peerjs 
-const peerjsHost = process.env.PEERJS_HOST || '127.0.0.1'
+const peerjsHost = process.env.PEERJS_HOST || '0.peerjs.com'
 const peerjsPath = process.env.PEERJS_PATH || '/'
 
 export async function POST(): Promise<NextResponse> {

--- a/src/app/api/ice/route.ts
+++ b/src/app/api/ice/route.ts
@@ -5,9 +5,16 @@ import { setTurnCredentials } from '../../../coturn'
 const turnHost = process.env.TURN_HOST || '127.0.0.1'
 const stunServer = process.env.STUN_SERVER || 'stun:stun.l.google.com:19302'
 
+// PATCH(gingermuffin):
+// Create host and path to local peerjs 
+const peerjsHost = process.env.PEERJS_HOST || '127.0.0.1'
+const peerjsPath = process.env.PEERJS_PATH || '/'
+
 export async function POST(): Promise<NextResponse> {
   if (!process.env.COTURN_ENABLED) {
     return NextResponse.json({
+      host: peerjsHost, 
+      path: peerjsPath,
       iceServers: [{ urls: stunServer }],
     })
   }
@@ -21,6 +28,8 @@ export async function POST(): Promise<NextResponse> {
   await setTurnCredentials(username, password, ttl)
 
   return NextResponse.json({
+    host: peerjsHost, 
+    path: peerjsPath,
     iceServers: [
       { urls: stunServer },
       {

--- a/src/components/WebRTCProvider.tsx
+++ b/src/components/WebRTCProvider.tsx
@@ -34,13 +34,17 @@ async function getOrCreateGlobalPeer(): Promise<Peer> {
     const response = await fetch('/api/ice', {
       method: 'POST',
     })
-    const { iceServers } = await response.json()
+    const { host, path, iceServers } = await response.json()
     console.log('[WebRTCProvider] ICE servers:', iceServers)
+    console.log('[WebRTCProvider] host:', host)
+    console.log('[WebRTCProvider] path:', path)
 
     globalPeer = new Peer({
       debug: 3,
       config: {
         iceServers,
+        host,
+        path,
       },
     })
   }


### PR DESCRIPTION
Thank you for FilePizza! It's an amazing project!
I’m running FilePizza as part of my homelab. In my setup, I want all services to operate fully offline and make external network requests as little as possible. So that's why, I decided to run PeerJS server locally.

### Changes:
Added two new configuration options that allow FilePizza to connect to a local PeerJS server.
I use the same defaults as in PeerJS ([https://peerjs.com/docs/](https://peerjs.com/docs/))

### Verification:
FilePizza runs entirely inside my local network without making any external requests to public PeerJS servers.